### PR TITLE
Update to runit services

### DIFF
--- a/sv/Makefile
+++ b/sv/Makefile
@@ -5,7 +5,7 @@ SVDIR=$(SYSCONFDIR)/sv
 install: FRC
 	for f in daily hourly weekly monthly; do \
 		mkdir -p $(DESTDIR)$(SVDIR)/snooze-$$f; \
-		install -m0755 snooze-$$f/run snooze-$$f/finish \
+		install -m0755 snooze-$$f/run \
 			$(DESTDIR)$(SVDIR)/snooze-$$f/; \
 	done
 

--- a/sv/snooze-daily/finish
+++ b/sv/snooze-daily/finish
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec touch /var/cache/snooze/daily

--- a/sv/snooze-daily/run
+++ b/sv/snooze-daily/run
@@ -1,4 +1,4 @@
 #!/bin/sh
 mkdir -p /var/cache/snooze
 exec snooze -s 1d -t /var/cache/snooze/daily -- sh -c \
-	"run-parts --lsbsysinit /etc/cron.daily; : > /var/cache/snooze/daily"
+	"test -d /etc/cron.daily && run-parts --lsbsysinit /etc/cron.daily; : > /var/cache/snooze/daily"

--- a/sv/snooze-daily/run
+++ b/sv/snooze-daily/run
@@ -1,3 +1,4 @@
 #!/bin/sh
 mkdir -p /var/cache/snooze
-exec snooze -s 1d -t /var/cache/snooze/daily -- run-parts --lsbsysinit /etc/cron.daily
+exec snooze -s 1d -t /var/cache/snooze/daily -- sh -c \
+	"run-parts --lsbsysinit /etc/cron.daily; : > /var/cache/snooze/daily"

--- a/sv/snooze-hourly/finish
+++ b/sv/snooze-hourly/finish
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec touch /var/cache/snooze/hourly

--- a/sv/snooze-hourly/run
+++ b/sv/snooze-hourly/run
@@ -1,4 +1,4 @@
 #!/bin/sh
 mkdir -p /var/cache/snooze
 exec snooze -H \* -s 1h -t /var/cache/snooze/hourly -- sh -c \
-	"run-parts --lsbsysinit /etc/cron.hourly; : > /var/cache/snooze/hourly"
+	"test -d /etc/cron.hourly && run-parts --lsbsysinit /etc/cron.hourly; : > /var/cache/snooze/hourly"

--- a/sv/snooze-hourly/run
+++ b/sv/snooze-hourly/run
@@ -1,3 +1,4 @@
 #!/bin/sh
 mkdir -p /var/cache/snooze
-exec snooze -H \* -s 1h -t /var/cache/snooze/hourly -- run-parts --lsbsysinit /etc/cron.hourly
+exec snooze -H \* -s 1h -t /var/cache/snooze/hourly -- sh -c \
+	"run-parts --lsbsysinit /etc/cron.hourly; : > /var/cache/snooze/hourly"

--- a/sv/snooze-monthly/finish
+++ b/sv/snooze-monthly/finish
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec touch /var/cache/snooze/monthly

--- a/sv/snooze-monthly/run
+++ b/sv/snooze-monthly/run
@@ -1,4 +1,4 @@
 #!/bin/sh
 mkdir -p /var/cache/snooze
 exec snooze -d 1 -s 28d -t /var/cache/snooze/monthly -- sh -c \
-	"run-parts --lsbsysinit /etc/cron.monthly; : > /var/cache/snooze/monthly"
+	"test -d /etc/cron.monthly && run-parts --lsbsysinit /etc/cron.monthly; : > /var/cache/snooze/monthly"

--- a/sv/snooze-monthly/run
+++ b/sv/snooze-monthly/run
@@ -1,3 +1,4 @@
 #!/bin/sh
 mkdir -p /var/cache/snooze
-exec snooze -d 1 -s 28d -t /var/cache/snooze/monthly -- run-parts --lsbsysinit /etc/cron.monthly
+exec snooze -d 1 -s 28d -t /var/cache/snooze/monthly -- sh -c \
+	"run-parts --lsbsysinit /etc/cron.monthly; : > /var/cache/snooze/monthly"

--- a/sv/snooze-weekly/finish
+++ b/sv/snooze-weekly/finish
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec touch /var/cache/snooze/weekly

--- a/sv/snooze-weekly/run
+++ b/sv/snooze-weekly/run
@@ -1,4 +1,4 @@
 #!/bin/sh
 mkdir -p /var/cache/snooze
 exec snooze -w 0 -s 7d -t /var/cache/snooze/weekly -- sh -c \
-	"run-parts --lsbsysinit /etc/cron.weekly; : > /var/cache/snooze/weekly"
+	"test -d /etc/cron.weekly && run-parts --lsbsysinit /etc/cron.weekly; : > /var/cache/snooze/weekly"

--- a/sv/snooze-weekly/run
+++ b/sv/snooze-weekly/run
@@ -1,3 +1,4 @@
 #!/bin/sh
 mkdir -p /var/cache/snooze
-exec snooze -w 0 -s 7d -t /var/cache/snooze/weekly -- run-parts --lsbsysinit /etc/cron.weekly
+exec snooze -w 0 -s 7d -t /var/cache/snooze/weekly -- sh -c \
+	"run-parts --lsbsysinit /etc/cron.weekly; : > /var/cache/snooze/weekly"


### PR DESCRIPTION
* updates the timefile mtime from the run script, so a finish file is no longer necessary
* tests if the relevant cron directory exists before invoking run-parts

The second change avoids errors such as:

    run-parts: failed to open directory /etc/cron.hourly: No such file or directory