### PR TITLE
snooze: remove unused include

### DIFF
--- a/snooze.c
+++ b/snooze.c
@@ -18,10 +18,6 @@
 #include <time.h>
 #include <unistd.h>
 
-#ifdef __linux__
-#include <sys/auxv.h>
-#endif
-
 static long slack = 60;
 #define SLEEP_PHASE 300
 static int nflag, vflag;


### PR DESCRIPTION
The `#include <sys/auxv.h>` was orinally included in the initial commit (see [1]) to use the `getauxval` function declaration.

This function usage has since been removed in commit [2].

This commit removes the include that is no longer needed.

[1] https://github.com/leahneukirchen/snooze/commit/56480881978a4cb5813746232de9950d46cb3369
[2] https://github.com/leahneukirchen/snooze/commit/610e6b35ec614764770d47b5974b30fd90dce6fe