### PR TITLE
Fix -H*/4 running every hour

### DIFF
--- a/snooze.c
+++ b/snooze.c
@@ -123,6 +123,8 @@ parse(char *expr, char *buf, long bufsiz, int offset)
 		case '*':
 			s++;
 			n = -offset;
+			if (*s == '/')  // cron-style */N, same as /N
+				break;
 			memset(buf, '*', bufsiz);
 			break;
 		default:


### PR DESCRIPTION
An * is parsed as "every hour", even if followed by a slash. For users familiar with cron, this is unexpected, and realistically, nobody should be using `*/4` to mean "every hour".

Ignore an asterisk that's followed by a slash.