### PR TITLE
Fix wrong formatting string for size_t

### DIFF
--- a/snooze.c
+++ b/snooze.c
@@ -49,7 +49,7 @@ parse_int(char **s, size_t minn, size_t maxn)
 		exit(1);
 	}
 	if (n < (long)minn || n >= (long)maxn) {
-		fprintf(stderr, "number outside %zd <= n < %zd\n", minn, maxn);
+		fprintf(stderr, "number outside %zu <= n < %zu\n", minn, maxn);
 		exit(1);
 	}
 	*s = end;


### PR DESCRIPTION
size_t is unsigned; its correct formatting string is %zu

Surfaced via:

    gcc -Wall -Wextra -Wformat-signedness snooze.c