### PR TITLE
Revised fixes

### DIFF
--- a/snooze.c
+++ b/snooze.c
@@ -114,6 +114,11 @@ parse(char *expr, char *buf, size_t bufsiz, int offset)
 	long min_val = -offset;
 	long max_val = bufsiz - 1 - offset;
 
+	if (!*s) {
+		fprintf(stderr, "empty time expression\n");
+		exit(1);
+	}
+
 	memset(buf, ' ', bufsiz);
 
 	while (*s) {
@@ -158,6 +163,10 @@ parse(char *expr, char *buf, size_t bufsiz, int offset)
 
 		if (*s == ',') {
 			s++;
+			if (!*s) {
+				fprintf(stderr, "trailing comma in expression: '%s'\n", expr);
+				exit(1);
+			}
 		} else if (*s) {
 			fprintf(stderr, "can't parse '%s': error on '%s'\n", expr, s);
 			exit(1);

--- a/snooze.c
+++ b/snooze.c
@@ -35,8 +35,8 @@ static volatile sig_atomic_t alarm_rang = 0;
 static void
 wakeup(int sig)
 {
-	(void)sig;
-	alarm_rang = 1;
+	if (sig == SIGALRM)
+		alarm_rang = 1;
 }
 
 static long
@@ -411,6 +411,7 @@ main(int argc, char *argv[])
 	sigset_t alarm_set, original_mask, wait_mask;
 	sigemptyset(&alarm_set);
 	sigaddset(&alarm_set, SIGALRM);
+	sigaddset(&alarm_set, SIGCONT);
 	if (sigprocmask(SIG_BLOCK, &alarm_set, &original_mask) < 0) {
 		perror("sigprocmask");
 		exit(2);
@@ -422,9 +423,11 @@ main(int argc, char *argv[])
 	};
 	sigfillset(&sa.sa_mask);
 	sigaction(SIGALRM, &sa, 0);
+	sigaction(SIGCONT, &sa, 0);
 
 	wait_mask = original_mask;
 	sigdelset(&wait_mask, SIGALRM);
+	sigdelset(&wait_mask, SIGCONT);
 
 	while (!alarm_rang) {
 		now = time(0);

--- a/snooze.c
+++ b/snooze.c
@@ -222,7 +222,6 @@ next_day:
 		tm->tm_hour = 0;
 
 		t = mktime(tm);
-		tm->tm_isdst = -1;
 
 		if (search_too_far(t, from))
 			return -1;

--- a/snooze.c
+++ b/snooze.c
@@ -6,6 +6,9 @@
  * http://creativecommons.org/publicdomain/zero/1.0/
  */
 
+#define _XOPEN_SOURCE 700
+
+#include <sys/select.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -404,12 +407,24 @@ main(int argc, char *argv[])
 	if (vflag)
 		printf("Snoozing until %s\n", isotime(tm));
 
-	// setup SIGALRM handler to force early execution
-	struct sigaction sa = { 0 };
-	sa.sa_handler = &wakeup;
-	sa.sa_flags = SA_RESTART;
+	// allow external SIGALRM to trigger immediate execution
+	sigset_t alarm_set, original_mask, wait_mask;
+	sigemptyset(&alarm_set);
+	sigaddset(&alarm_set, SIGALRM);
+	if (sigprocmask(SIG_BLOCK, &alarm_set, &original_mask) < 0) {
+		perror("sigprocmask");
+		exit(2);
+	}
+
+	struct sigaction sa = {
+		.sa_handler = wakeup,
+		.sa_flags = 0
+	};
 	sigfillset(&sa.sa_mask);
-	sigaction(SIGALRM, &sa, NULL);
+	sigaction(SIGALRM, &sa, 0);
+
+	wait_mask = original_mask;
+	sigdelset(&wait_mask, SIGALRM);
 
 	while (!alarm_rang) {
 		now = time(0);
@@ -440,12 +455,19 @@ main(int argc, char *argv[])
 					printf("Snoozing until %s\n", isotime(tm));
 			}
 		} else {
-			// do some sleeping, but not more than SLEEP_PHASE
-			struct timespec ts;
-			ts.tv_nsec = 0;
-			ts.tv_sec = t - now > SLEEP_PHASE ? SLEEP_PHASE : t - now;
 			last = now;
-			nanosleep(&ts, 0);
+
+ 			// do some sleeping, but not more than SLEEP_PHASE
+			struct timespec ts = {
+				.tv_sec = t - now > SLEEP_PHASE ? SLEEP_PHASE : t - now,
+				.tv_nsec = 0,
+			};
+			if (pselect(0, 0, 0, 0, &ts, &wait_mask) < 0) {
+				if (errno != EINTR) {
+					perror("pselect");
+					exit(2);
+				}
+			}
 			// we just iterate again when this exits early
 		}
 	}
@@ -454,6 +476,11 @@ main(int argc, char *argv[])
 		now = time(0);
 		tm = localtime(&now);
 		printf("Starting execution at %s\n", isotime(tm));
+	}
+
+	if (sigprocmask(SIG_SETMASK, &original_mask, 0) < 0) {
+		perror("sigprocmask");
+		exit(2);
 	}
 
 	// no command to run, the outside script can go on

--- a/snooze.c
+++ b/snooze.c
@@ -86,47 +86,56 @@ parse_dur(char *s)
 static int
 parse(char *expr, char *buf, long bufsiz, int offset)
 {
-	char *s;
-	long i, n = -offset, n0 = 0;
+	char *s = expr;
+	long min_val = -offset;
+	long max_val = bufsiz - 1 - offset;
 
 	memset(buf, ' ', bufsiz);
 
-	s = expr;
 	while (*s) {
-		switch (*s) {
-		case '0': case '1': case '2': case '3': case '4':
-		case '5': case '6': case '7': case '8': case '9':
-			n = parse_int(&s, -offset, bufsiz);
-			buf[n+offset] = '*';
-			break;
-		case '-':
-			n0 = n;
+		long start, end;
+		long step = 1;
+
+		if (*s == '*') {
+			start = min_val;
+			end = max_val;
 			s++;
-			n = parse_int(&s, -offset, bufsiz);
-			for (i = n0; i <= n; i++)
-				buf[i+offset] = '*';
-			break;
-		case '/':
+		} else if (*s == '/') {
+			start = min_val;
+			end = max_val;
+		} else if (*s >= '0' && *s <= '9') {
+			start = parse_int(&s, min_val, bufsiz);
+			if (*s == '-') {
+				s++;
+				end = parse_int(&s, min_val, bufsiz);
+			} else if (*s == '/') {
+				end = max_val;
+			} else {
+				end = start;
+			}
+		} else {
+			fprintf(stderr, "can't parse '%s': error on '%s'\n", expr, s);
+			exit(1);
+		}
+
+		if (*s == '/') {
 			s++;
-			n0 = n;
-			if (*s)
-				n = parse_int(&s, -offset, bufsiz);
-			if (n == 0)  // / = *
-				n = 1;
-			for (i = n0; i < bufsiz; i += n)
-				buf[i+offset] = '*';
-			break;
-		case ',':
+			if (*s >= '0' && *s <= '9')
+				step = parse_int(&s, 1, bufsiz);
+		}
+
+		if (start > end) {
+			fprintf(stderr, "invalid range: %ld-%ld\n", start, end);
+			exit(1);
+		}
+
+		for (long i = start; i <= end; i += step)
+			buf[i + offset] = '*';
+
+		if (*s == ',') {
 			s++;
-			n = -offset;
-			break;
-		case '*':
-			s++;
-			n = -offset;
-			memset(buf, '*', bufsiz);
-			break;
-		default:
-			fprintf(stderr, "can't parse: %s %s\n", expr, s);
+		} else if (*s) {
+			fprintf(stderr, "can't parse '%s': error on '%s'\n", expr, s);
 			exit(1);
 		}
 	}

--- a/snooze.c
+++ b/snooze.c
@@ -19,6 +19,7 @@
 
 static long slack = 60;
 #define SLEEP_PHASE 300
+#define MAX_DURATION (366L * 24 * 60 * 60)
 static int nflag, vflag;
 
 static long timewait = -1;
@@ -99,7 +100,7 @@ parse_dur(char *s)
 		exit(1);
 	}
 
-	if (n > 366L * 24 * 60 * 60) {
+	if (n > MAX_DURATION) {
 		fprintf(stderr, "duration out of range: %s\n", s);
 		exit(1);
 	}
@@ -198,7 +199,7 @@ isoweek(struct tm *tm)
 static int
 search_too_far(time_t t, time_t from)
 {
-	return t == (time_t)-1 || t < from || t - from > (time_t)366 * 24 * 60 * 60;
+	return t == (time_t)-1 || t < from || t - from > (time_t)MAX_DURATION;
 }
 
 time_t

--- a/snooze.c
+++ b/snooze.c
@@ -262,7 +262,7 @@ next_day:
 
 	if (jitter > 0 && !nflag) {
 		long delay;
-		delay = lrand48() % jitter;
+		delay = lrand48() % (jitter + 1);
 		if (vflag)
 			printf("adding %lds for jitter.\n", delay);
 		t += delay;
@@ -359,7 +359,7 @@ main(int argc, char *argv[])
 
 	if (randdelay > 0) {
 		long delay;
-		delay = lrand48() % randdelay;
+		delay = lrand48() % (randdelay + 1);
 		if (vflag)
 			printf("randomly delaying by %lds.\n", delay);
 		start += delay;

--- a/snooze.c
+++ b/snooze.c
@@ -62,21 +62,17 @@ parse_int(char **s, long minn, long maxn)
 static long
 parse_dur(char *s)
 {
-	long n;
+	unsigned long n;
 	char *end;
 
 	errno = 0;
-	n = strtol(s, &end, 10);
+	n = strtoul(s, &end, 10);
 	if (errno) {
-		perror("strtol");
+		perror("strtoul");
 		exit(1);
 	}
 	if (end == s) {
 		fprintf(stderr, "invalid duration: '%s'\n", s);
-		exit(1);
-	}
-	if (n < 0) {
-		fprintf(stderr, "negative duration\n");
 		exit(1);
 	}
 

--- a/snooze.c
+++ b/snooze.c
@@ -108,7 +108,7 @@ parse_dur(char *s)
 }
 
 static int
-parse(char *expr, char *buf, long bufsiz, int offset)
+parse(char *expr, char *buf, size_t bufsiz, int offset)
 {
 	char *s = expr;
 	long min_val = -offset;
@@ -186,6 +186,12 @@ isoweek(struct tm *tm)
 	return parse_int(&w, 1, 54);
 }
 
+static int
+search_too_far(time_t t, time_t from)
+{
+	return t == (time_t)-1 || t < from || t - from > (time_t)366 * 24 * 60 * 60;
+}
+
 time_t
 find_next(time_t from)
 {
@@ -218,7 +224,7 @@ next_day:
 		t = mktime(tm);
 		tm->tm_isdst = -1;
 
-		if (t < from || t - from > (time_t)366*24*60*60)  // no result within a year
+		if (search_too_far(t, from))
 			return -1;
 	}
 
@@ -239,6 +245,8 @@ next_day:
 			tm->tm_sec++;
 		}
 		t = mktime(tm);
+		if (search_too_far(t, from))
+			return -1;
 		if (tm->tm_yday != y)  // hit a different day, retry...
 			goto next_day;
 	}

--- a/snooze.c
+++ b/snooze.c
@@ -360,6 +360,11 @@ main(int argc, char *argv[])
 		now = time(0);
 		if (now < last) {
 			t = find_next(now);
+			if (t < 0) {
+				fprintf(stderr, "no satisfying date found within a year.\n");
+				exit(2);
+			}
+			tm = localtime(&t);
 			if (vflag)
 				printf("Time moved backwards, rescheduled for %s\n", isotime(tm));
 		}

--- a/snooze.c
+++ b/snooze.c
@@ -99,6 +99,11 @@ parse_dur(char *s)
 		exit(1);
 	}
 
+	if (n > 366L * 24 * 60 * 60) {
+		fprintf(stderr, "duration out of range: %s\n", s);
+		exit(1);
+	}
+
 	return n;
 }
 
@@ -213,7 +218,7 @@ next_day:
 		t = mktime(tm);
 		tm->tm_isdst = -1;
 
-		if (t > from+(366*24*60*60))  // no result within a year
+		if (t < from || t - from > (time_t)366*24*60*60)  // no result within a year
 			return -1;
 	}
 

--- a/snooze.c
+++ b/snooze.c
@@ -21,9 +21,9 @@ static long slack = 60;
 #define SLEEP_PHASE 300
 static int nflag, vflag;
 
-static int timewait = -1;
-static int randdelay = 0;
-static int jitter = 0;
+static long timewait = -1;
+static long randdelay = 0;
+static long jitter = 0;
 static char *timefile;
 
 static volatile sig_atomic_t alarm_rang = 0;
@@ -250,7 +250,7 @@ next_day:
 			goto next_day;
 	}
 
-	if (jitter && !nflag) {
+	if (jitter > 0 && !nflag) {
 		long delay;
 		delay = lrand48() % jitter;
 		if (vflag)
@@ -347,7 +347,7 @@ main(int argc, char *argv[])
 
 	srand48(getpid() ^ start);
 
-	if (randdelay) {
+	if (randdelay > 0) {
 		long delay;
 		delay = lrand48() % randdelay;
 		if (vflag)
@@ -376,7 +376,7 @@ main(int argc, char *argv[])
 			    ((int)(t - now) / 60) % 60,
 			    (int)(t - now) % 60);
 			if(jitter) {
-				printf("(plus up to %ds for jitter)\n", jitter);
+				printf("(plus up to %lds for jitter)\n", jitter);
 			} else {
 				printf("\n");
 			}

--- a/snooze.c
+++ b/snooze.c
@@ -36,7 +36,7 @@ wakeup(int sig)
 }
 
 static long
-parse_int(char **s, size_t minn, size_t maxn)
+parse_int(char **s, long minn, long maxn)
 {
 	long n;
 	char *end;
@@ -47,8 +47,12 @@ parse_int(char **s, size_t minn, size_t maxn)
 		perror("strtol");
 		exit(1);
 	}
-	if (n < (long)minn || n >= (long)maxn) {
-		fprintf(stderr, "number outside %zu <= n < %zu\n", minn, maxn);
+	if (end == *s) {
+		fprintf(stderr, "expected number, got: %s\n", *s);
+		exit(1);
+	}
+	if (n < minn || n >= maxn) {
+		fprintf(stderr, "number outside %ld <= n < %ld\n", minn, maxn);
 		exit(1);
 	}
 	*s = end;
@@ -67,19 +71,38 @@ parse_dur(char *s)
 		perror("strtol");
 		exit(1);
 	}
+	if (end == s) {
+		fprintf(stderr, "invalid duration: '%s'\n", s);
+		exit(1);
+	}
 	if (n < 0) {
 		fprintf(stderr, "negative duration\n");
 		exit(1);
 	}
+
+	if (end[0] && end[1]) {
+		end++;
+		goto junk;
+	}
+
 	switch (*end) {
-	case 'm': n *= 60; break;
-	case 'h': n *= 60*60; break;
-	case 'd': n *= 24*60*60; break;
-	case 0: break;
+	case 'm':
+		n *= 60;
+		break;
+	case 'h':
+		n *= 60*60;
+		break;
+	case 'd':
+		n *= 24*60*60;
+		break;
+	case 0:
+		break;
 	default:
+	junk:
 		fprintf(stderr, "junk after duration: %s\n", end);
 		exit(1);
 	}
+
 	return n;
 }
 

--- a/snooze.c
+++ b/snooze.c
@@ -323,8 +323,13 @@ main(int argc, char *argv[])
 			t = st.st_mtime + 1;
 		}
 		if (timewait == -1) {
-			while (t < start - slack)
+			while (t < start - slack) {
 				t = find_next(t + 1);
+				if (t < 0) {
+					fprintf(stderr, "no satisfying date found within a year.\n");
+					exit(2);
+				}
+			}
 			start = t;
 		} else {
 			if (t + timewait > start - slack)
@@ -408,6 +413,10 @@ main(int argc, char *argv[])
 				if (vflag)
 					printf("Missed execution at %s\n", isobuf);
 				t = find_next(now + 1);
+				if (t < 0) {
+					fprintf(stderr, "no satisfying date found within a year.\n");
+					exit(2);
+				}
 				tm = localtime(&t);
 				if (vflag)
 					printf("Snoozing until %s\n", isotime(tm));


### PR DESCRIPTION
Supersedes #32.
Closes #29.

I simplified some code, adjusted style, made error message clearer.

I removed some error handling / defensive programming that is not relevant in practice.  Let's keep the code clean.

I think the `tm_isdst` change was actually introducing a bug, cf.:
```
% TZ=Europe/Berlin ./snooze -m10 -d25 -H1-10  -n    
2026-10-25T01:00:00+0200 Sun 80d  4h 48m 57s 
2026-10-25T02:00:00+0200 Sun 80d  5h 48m 57s 
2026-10-25T03:00:00+0100 Sun 80d  7h 48m 57s 
2026-10-25T04:00:00+0100 Sun 80d  8h 48m 57s 
2026-10-25T05:00:00+0100 Sun 80d  9h 48m 57s 
```

This skips one execution.